### PR TITLE
Makes notification popup display 'error' icon when there are errors in tests

### DIFF
--- a/lib/guard/test/formatter.rb
+++ b/lib/guard/test/formatter.rb
@@ -9,7 +9,7 @@ module Formatter
   def notify_results(test_count, assertion_count, failure_count, error_count, duration)
     notify(
       results_text(test_count, assertion_count, failure_count, error_count) + duration_text(duration, :short => true),
-      image(failure_count)
+      image(failure_count+error_count)
     )
   end
   


### PR DESCRIPTION
Current version only shows 'error' icon when there are assertion failures.
It is confusing since any change that creates a runtime error (thus skipping assertions) is "ignored" and the 'ok' icon is displayed.

I also tried to add the same behavior to compilation errors but unfortunately couldn't figure out how to do it.
It probably requires running the tests in a fork.
