### PR TITLE
Fixed bug for running all test with "test_*.rb" file

### DIFF
--- a/lib/guard/test/inspector.rb
+++ b/lib/guard/test/inspector.rb
@@ -13,6 +13,7 @@ module Guard
             if File.directory?(path)
               paths.delete(path)
               paths += Dir.glob("#{path}/**/*_test.rb")
+              paths += Dir.glob("#{path}/**/test_*.rb")
             end
           end
 

--- a/lib/guard/test/runners/default_guard_test_runner.rb
+++ b/lib/guard/test/runners/default_guard_test_runner.rb
@@ -5,6 +5,17 @@ require 'test/unit/ui/console/testrunner'
 require 'guard/test/ui'
 require 'guard/test/notifier'
 
+# copy this snippet from rake_test_loader.rb
+ARGV.each do |f|
+  next if f =~ /^-/
+
+  if f =~ /\*/
+    FileList[f].to_a.each { |fn| require File.expand_path(fn) }
+  else
+    require File.expand_path(f)
+  end
+end
+
 # Thanks to Adam Sanderson for the really good starting point:
 # http://endofline.wordpress.com/2008/02/11/a-custom-testrunner-to-scratch-an-itch/
 #


### PR DESCRIPTION
1.
I am using "test_*.rb" file for test.
But these files were not included as test files in instector.rb.
So I fixed to add these files.
2.
"Run all" was not work for me.
So I copy the snippet which execute multiple files from rake_test_loader.rb.
