### PR TITLE
Guard::Test::Notifier.notify - did not use :failed image if test results included errors but NO failures

### DIFF
--- a/lib/guard/test/notifier.rb
+++ b/lib/guard/test/notifier.rb
@@ -13,7 +13,7 @@ module Guard
           ::Guard::Notifier.notify(
             summary(result) + "\n\n" + duration(elapsed_time),
             :title => "Test::Unit results",
-            :image => result.failure_count > 0 ? :failed : :success
+            :image => result.passed? ? :success : :failed
           )
         end
 

--- a/spec/guard/test/notifier_spec.rb
+++ b/spec/guard/test/notifier_spec.rb
@@ -1,3 +1,4 @@
+
 # encoding: utf-8
 require 'spec_helper'
 require 'guard/test/notifier'
@@ -7,27 +8,36 @@ describe Guard::Test::Notifier do
   describe "#notify(result, duration)" do
     context "no failure, no error" do
       it "displays a 'success' image" do
-        result = mock('result', :run_count => 1, :assertion_count => 1, :failure_count => 0, :error_count => 0)
-        Guard::Notifier.should_receive(:notify).with(any_args, :title => "Test::Unit results", :image => :success)
+        result = create_mock_result
+        Guard::Notifier.should_receive(:notify).with(anything, :title => "Test::Unit results", :image => :success)
         described_class.notify(result, 0)
       end
     end
 
     context "1 failure" do
       it "displays a 'failed' image" do
-        result = mock('result', :run_count => 1, :assertion_count => 1, :failure_count => 1, :error_count => 0)
-        Guard::Notifier.should_receive(:notify).with(any_args, :title => "Test::Unit results", :image => :failed)
+        result = create_mock_result(:failure_count => 1)
+        Guard::Notifier.should_receive(:notify).with(anything, :title => "Test::Unit results", :image => :failed)
         described_class.notify(result, 0)
       end
     end
 
     context "1 error" do
       it "displays a 'failed' image" do
-        result = mock('result', :run_count => 1, :assertion_count => 1, :failure_count => 0, :error_count => 1)
-        Guard::Notifier.should_receive(:notify).with(any_args, :title => "Test::Unit results", :image => :failed)
+        result = create_mock_result(:error_count => 1)
+        Guard::Notifier.should_receive(:notify).with(anything, :title => "Test::Unit results", :image => :failed)
         described_class.notify(result, 0)
       end
     end
   end
 
 end
+
+def create_mock_result(options={})
+  default = {:run_count => 1, :assertion_count => 1, :failure_count => 0, :error_count => 0}
+  options = default.merge(options)
+  # passed? if no failures or errors
+  options[:passed?] = (0 == options[:failure_count] && 0 == options[:error_count])
+  mock('result', options)
+end
+


### PR DESCRIPTION
I am a github/ruby noob so i apologize if the pull request is screwy.

==hole is spec coverage==
the notifier_spec.rb covered results with errors and no failures as well as failures and no errors.  unfortunately the spec used the "any_args" argument matcher when setting up the expectations for how Guard::Notifier.notify would be invoked.  "any_args" causes any value to be accepted for all of the args.  I replaced this with the use of the "anything" arg matcher for the first argument - which accepts any value for just the first argument.

==use of result.passed?==
i changed Guard::Test::Notifier.notify to determine success/failure based on the value returned by "passed?".  I refactored the spec a little bit.  this was done to dry up the options used to generate the mock and to ensure that the return value for "passed?" was derived.

Please let me know if you want me to make any additional changes to the spec or lib class.

Carlos
