### PR TITLE
Minitest support (usefull for rails 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Please read the [Guard documentation](https://github.com/guard/guard#readme) for
 * `rubygems` (`Boolean`)         - Whether or not to require rubygems (if bundler isn't used) when running the tests. Default to `false`.
 * `rvm` (`Array<String>`)        - Directly run your specs against multiple Rubies. Default to `nil`.
 * `drb` (`Boolean`)              - Run your tests with [`spork-testunit`](https://github.com/timcharper/spork-testunit). Default to `false`.
+* `minitest` (`Boolean`)         - Run your tests with [`minitest`]. Default to `false`.
 * `include` (`Array<String>`)    - Pass arbitrary include paths to the command that runs the tests. Default to `['test']`.
 * `cli` (`String`)               - Pass arbitrary CLI arguments to the command that runs the tests. Default to `nil`.
 * `all_on_start` (`Boolean`)     - Run all tests on Guard startup. Default to `true`.

--- a/lib/guard/test/runner.rb
+++ b/lib/guard/test/runner.rb
@@ -11,6 +11,7 @@ module Guard
           :rvm      => [],
           :include  => ['test'],
           :drb      => false,
+          :minitest => false,
           :cli      => ''
         }.merge(options)
       end
@@ -21,6 +22,13 @@ module Guard
         ::Guard::UI.info(options[:message] || "Running: #{paths.join(' ')}", :reset => true)
 
         system(test_unit_command(paths))
+      end
+
+      def minitest?
+        if @minitest.nil?
+          @minitest = @options[:minitest] && !drb?
+        end
+        @minitest
       end
 
       def bundler?
@@ -69,9 +77,12 @@ module Guard
 
         paths.each { |path| cmd_parts << "\"./#{path}\"" }
 
-        unless drb?
-          cmd_parts << '--use-color'
-          cmd_parts << '--runner=guard'
+
+
+
+        if !drb? and !minitest?
+           cmd_parts << '--use-color'
+           cmd_parts << '--runner=guard'
         end
 
         cmd_parts << @options[:cli]


### PR DESCRIPTION
Now Rails 4 use minitest by default (https://github.com/rails/rails/blob/master/activesupport/lib/active_support/test_case.rb) and some options are not yet supported by minitest like --use-color.

This patch allow the user to say the test gem is minitest.
