### PR TITLE
Add support for running tests via zeus

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Please read the [Guard documentation](https://github.com/guard/guard#readme) for
 * `rubygems` (`Boolean`)         - Whether or not to require rubygems (if bundler isn't used) when running the tests. Default to `false`.
 * `rvm` (`Array<String>`)        - Directly run your specs against multiple Rubies. Default to `nil`.
 * `drb` (`Boolean`)              - Run your tests with [`spork-testunit`](https://github.com/timcharper/spork-testunit). Default to `false`.
+* `zeus` (`Boolean`)             - Run your tests with [`zeus`](https://github.com/burke/zeus). Default to `false`.
 * `include` (`Array<String>`)    - Pass arbitrary include paths to the command that runs the tests. Default to `['test']`.
 * `cli` (`String`)               - Pass arbitrary CLI arguments to the command that runs the tests. Default to `nil`.
 * `all_on_start` (`Boolean`)     - Run all tests on Guard startup. Default to `true`.
@@ -97,6 +98,12 @@ Please read the [Guard documentation](https://github.com/guard/guard#readme) for
 #### `drb` option
 
 When true, notifications are disabled. This might be fixed in future releases.
+
+#### `zeus` option
+
+When true, the `include` option is disregarded, as it does not work with `zeus`' test runner. 
+
+The zeus server process (`zeus start`) must already be running in another terminal.
 
 #### `test_paths` option
 

--- a/spec/guard/test/runner_spec.rb
+++ b/spec/guard/test/runner_spec.rb
@@ -11,6 +11,7 @@ describe Guard::Test::Runner do
         runner.instance_variable_get(:@options)[:rubygems].should be_false
         runner.instance_variable_get(:@options)[:rvm].should be_empty
         runner.instance_variable_get(:@options)[:drb].should be_false
+        runner.instance_variable_get(:@options)[:zeus].should be_false
         runner.instance_variable_get(:@options)[:cli].should eql ""
       end
 
@@ -27,6 +28,22 @@ describe Guard::Test::Runner do
           it "uses bundler but not drb" do
             runner = described_class.new(:drb => false, :bundler => true)
             runner.should_not be_drb
+            runner.should be_bundler
+          end
+        end
+
+        context "with the :zeus option set to true" do
+          it "uses zeus but not bundler" do
+            runner = described_class.new(:zeus => true, :bundler => true)
+            runner.should be_zeus
+            runner.should_not be_bundler
+          end
+        end
+
+        context "with the :zeus option set to false" do
+          it "uses bundler but not zeus" do
+            runner = described_class.new(:zeus => false, :bundler => true)
+            runner.should_not be_zeus
             runner.should be_bundler
           end
         end
@@ -61,6 +78,13 @@ describe Guard::Test::Runner do
         it "uses drb" do
           runner = described_class.new(:drb => true)
           runner.should be_drb
+        end
+      end
+
+      describe ":zeus option" do
+        it "uses zeus" do
+          runner = described_class.new(:zeus => true)
+          runner.should be_zeus
         end
       end
 
@@ -233,6 +257,19 @@ describe Guard::Test::Runner do
           )
 
           subject.run(["test/succeeding_test.rb"])
+        end
+
+        context "when the :zeus option is given" do
+          subject do
+            runner = described_class.new(:zeus => true)
+            runner
+          end
+
+          it "does not add a -I option" do
+            subject.should_not_receive(:system).with(/\-I/)
+
+            subject.run(["test/succeeding_test.rb"])
+          end 
         end
       end
 


### PR DESCRIPTION
Does not support the `include` option. Uses zeus' own test runner. 

(refs #37)
