### PR TITLE
add test_paths to zeus test command

### DIFF
--- a/lib/guard/test/runner.rb
+++ b/lib/guard/test/runner.rb
@@ -89,6 +89,7 @@ module Guard
       def includes_and_requires(paths)
         parts = []
         parts << Array(options[:include]).map { |path| "-I\"#{path}\"" } unless zeus? || spring?
+        parts << paths if zeus?
         parts << '-r bundler/setup' if bundler?
         parts << '-r rubygems' if rubygems?
 


### PR DESCRIPTION
Hello,
guard is crashing for me with error shown in https://github.com/burke/zeus/issues/358
on bug comments found that zeus test command should have test paths appended, as in README examples

regards,
Lluís
