### PR TITLE
Add paths to spring command when spring is enabled

### DIFF
--- a/lib/guard/test/runner.rb
+++ b/lib/guard/test/runner.rb
@@ -89,7 +89,7 @@ module Guard
       def includes_and_requires(paths)
         parts = []
         parts << Array(options[:include]).map { |path| "-I\"#{path}\"" } unless zeus? || spring?
-        parts << paths if zeus?
+        parts << paths if zeus? || spring?
         parts << '-r bundler/setup' if bundler?
         parts << '-r rubygems' if rubygems?
 


### PR DESCRIPTION
I am on Rails 3.2, Spring 1.1.0 and guard-test master. I'd like to be able to execute individual tests when using Spring.

From what I can see, the paths to the test files currently aren't added when using Spring, while https://github.com/jonleighton/spring-commands-testunit adds support to run "spring testunit <file>".

Would it be possible to enable adding paths to the spring command in the Runner? I did this by simply enabling this option in the Runner as per this pull request, but I am unsure if this breaks something with for example Rails 4.

Please let me know!
