### PR TITLE
bug fix for running spring tests under rails >= 4.0 without spring-comma...

### DIFF
--- a/lib/guard/test/runner.rb
+++ b/lib/guard/test/runner.rb
@@ -82,8 +82,17 @@ module Guard
         parts << case true
                  when drb? then 'testdrb'
                  when zeus? then 'zeus test'
-                 when spring? then 'spring testunit'
+                 when spring? then spring_command
                  else 'ruby'; end
+      end
+
+      def spring_command
+        if Gem.loaded_specs["rails"] && Gem.loaded_specs["rails"].version < Gem::Version.create('4.0')
+          'spring testunit'
+        else
+          # rails > 4.0 supports passing a path to rake test
+          'spring rake test'
+        end
       end
 
       def includes_and_requires(paths)


### PR DESCRIPTION
Just installed Rails 4.1 and enabled the built-in Spring integration. Found that guard fails with and without passing the option `spring: true`. Without the the spring option, the default runner `ruby` doesn't recognize the `--use-color` switch. With the spring option, it didn't recognize the `testunit` command. It turns out you don't need spring-commands-testunit under rails 4.x since `rake test` can accept a path as an argument.

This patch just does some rails version sniffing and changes the command appropriately.
