### PR TITLE
fix "NameError: uninitialized constant Guard::Test::TestVersion".

### DIFF
--- a/lib/guard/test.rb
+++ b/lib/guard/test.rb
@@ -1,4 +1,5 @@
 require 'guard/compat/plugin'
+require 'guard/test/version'
 require 'test/unit/version'
 
 module Guard


### PR DESCRIPTION
Hi,

When I tried to use `guard-test` which is currently master (245ccc92ff94cfa4ddfe901dbd9690b84c46b1ff), I got NameError. This pull-request fixes it.

---

Before this pull-request:

```
yuya@yoshiyuki|1:02:23|0% bundle exec guard
01:02:26 - INFO - Bundle already up-to-date
01:02:26 - ERROR - Guard::Test failed to achieve its <start>, exception was:
> [#F0AFF027CE0B] NameError: uninitialized constant Guard::Test::TestVersion
> [#F0AFF027CE0B] /home/yuya/.anyenv/envs/rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/bundler/gems/guard-test-245ccc92ff94/lib/guard/test.rb:25:in `start'
> [#F0AFF027CE0B] /home/yuya/.anyenv/envs/rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/guard-2.12.5/lib/guard/runner.rb:82:in `block in _supervise'
> [#F0AFF027CE0B] /home/yuya/.anyenv/envs/rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/guard-2.12.5/lib/guard/runner.rb:79:in `catch'
> [#F0AFF027CE0B] /home/yuya/.anyenv/envs/rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/guard-2.12.5/lib/guard/runner.rb:79:in `_supervise'
...
```

After this pull-request:

```
yuya@yoshiyuki|1:06:50|0% bundle exec guard
01:06:52 - INFO - Bundle already up-to-date
01:06:52 - INFO - Guard::Test 2.0.5 is running, with Test::Unit 3.0.9!
01:06:52 - INFO - Running all tests
Started
.

Finished in 0.008906032 seconds.
--------------------------------------------------------------------------------
1 tests, 1 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------
112.28 tests/s, 112.28 assertions/s
1 test, 1 assert, 0 fails, 0 errors

Finished in 0.0089 seconds
```
