### PR TITLE
Add test paths to the test command when running using spork drb.

### DIFF
--- a/lib/guard/test/runner.rb
+++ b/lib/guard/test/runner.rb
@@ -100,7 +100,7 @@ module Guard
       def includes_and_requires(paths)
         parts = []
         parts << Array(options[:include]).map { |path| "-I\"#{path}\"" } unless zeus? || spring?
-        parts << paths if zeus? || spring?
+        parts << paths if zeus? || spring? || drb?
         parts << '-r bundler/setup' if bundler?
         parts << '-r rubygems' if rubygems?
 


### PR DESCRIPTION
Much like #52, `testdrb` requires the paths to the test files, see http://stackoverflow.com/questions/21262151/guard-fail-error-exit-code-1-spork-and-testunit for a description of the problem.