### PR TITLE
Ensure that Test::Unit::AutoRunner is loaded in GuardTestRunner

### DIFF
--- a/lib/guard/test/guard_test_runner.rb
+++ b/lib/guard/test/guard_test_runner.rb
@@ -1,3 +1,4 @@
+require 'test/unit/autorunner'
 require 'test/unit/ui/console/testrunner'
 require 'guard/test/notifier'
 


### PR DESCRIPTION
@mitsuru793 Could you please try using this branch and see if that fixes #60?

You can use this branch by setting the following in your Gemfile:

```ruby
gem 'guard-test', github: 'guard/guard-test', branch: 'fix-60'
```

Fixes #60.