### PR TITLE
Update for latest version of guard

### DIFF
--- a/lib/guard/test/runner.rb
+++ b/lib/guard/test/runner.rb
@@ -116,7 +116,7 @@ module Guard
         if drb? || zeus? || spring?
           []
         else
-          ['--', '--use-color', '--runner=guard_test']
+          ['--', '--color']
         end
       end
 


### PR DESCRIPTION
Hello, i think this would be a major version bump but wanted to at least put it our there for discussion.  I installed guard-test on a rails 6 project and the options in the runner are no longer supported with newer versions of guard.   Pulling the gem locally and updating the runner as in this PR allowed to get the visual feedback and guard ran properly